### PR TITLE
fix: getItemsByPath sorting stability

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,9 @@ export function getItemsByPath(items, pathname) {
   const matchingPaths = Object.keys(itemsByPath)
     .filter((path) => pathname.startsWith(path))
     .sort((a, b) => {
-      return a.length < b.length;
+      if (a.length > b.length) return -1;
+      else if (a.length < b.length) return 1;
+      else return 0;
     });
 
   if (matchingPaths.length > 0) return itemsByPath[matchingPaths[0]].items;


### PR DESCRIPTION
Fixes an issue on certain situations where in nested config paths, the "parent" menu was rendered. 
This was happening on Chrome only, then I remembered how V8 (Chrome's JS engine) handles sorting in a different way and here we are.
Now I'm fixing the sorting stability so we have the correct path match on Chrome, too. Always. 

Test here: https://codesandbox.io/s/wonderful-butterfly-lcytx?file=/src/index.js
Docs: https://v8.dev/blog/array-sort
