### PR TITLE
Volto crash if you don't initialize content from Plone

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,14 @@
 export function getItemsByPath(items, pathname) {
   let rootPathConfig = null;
-  const itemsByPath = items?.reduce((acc, val) => {
-    if (val.rootPath === '/') {
-      rootPathConfig = val;
-      return acc;
-    }
-    return { ...acc, [val.rootPath]: val };
-  }, {});
+  const itemsByPath = Array.isArray(items)
+    ? items?.reduce((acc, val) => {
+        if (val.rootPath === '/') {
+          rootPathConfig = val;
+          return acc;
+        }
+        return { ...acc, [val.rootPath]: val };
+      }, {})
+    : [];
   const matchingPaths = Object.keys(itemsByPath)
     .filter((path) => pathname.startsWith(path))
     .sort((a, b) => {

--- a/src/widget/MenuConfigurationWidget.jsx
+++ b/src/widget/MenuConfigurationWidget.jsx
@@ -70,7 +70,7 @@ const defaultRootMenu = title => ({
   items: [defaultMenuItem(title)],
 });
 
-const defaultMenuConfiguration = [defaultRootMenu];
+const defaultMenuConfiguration = [defaultRootMenu(`Tab 0`)];
 
 const MenuConfigurationWidget = ({
   value,


### PR DESCRIPTION
If the addon information is not initialized from Plone, it gives an error when Volto starting.

This happens because state.dropdownMenuNavItems.items is an empty object {} and the reduce function is expecting an array.

To solve it, I checked if the items prop is an array, and if not, an empty array will be initialized.

[Reference](https://github.com/collective/volto-dropdownmenu/commit/83bb1a4f2272dd9df4c4737a7ae458a4abb5f10a#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52R3)

![items reduce_screenshot](https://user-images.githubusercontent.com/26112509/117139891-092fb100-adad-11eb-9b77-0afc812bc6fa.png)



Furthermore, when we create a new menu item for the first time, it breaks because the defaultRootMenu function expects a parameter.

[Reference](https://github.com/collective/volto-dropdownmenu/compare/master...codesyntax:reduce-bug?expand=1#diff-b65cba52506a373309942706409f75d21795df144d22f624359ccd34ace7a947R73)

![title_null_error](https://user-images.githubusercontent.com/26112509/117141421-cc64b980-adae-11eb-884f-82d5ce7fa452.gif)



### Result
![result](https://user-images.githubusercontent.com/26112509/117145133-15b70800-adb3-11eb-801d-313ac683f004.gif)
