### PR TITLE
fix: removed unused prevent click

### DIFF
--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -4,12 +4,11 @@ import { v4 as uuid } from 'uuid';
 import { isEmpty } from 'lodash';
 import { Form as UIForm, Grid, Button } from 'semantic-ui-react';
 import Sidebar from '@plone/volto/components/manage/Sidebar/Sidebar';
-import { Form } from '@plone/volto/components/manage/Form';
-import {
-  TextWidget,
-  CheckboxWidget,
-  ObjectBrowserWidget,
-} from '@plone/volto/components/manage/Widgets';
+import Form from '@plone/volto/components/manage/Form/Form';
+
+import TextWidget from '@plone/volto/components/manage/Widgets/TextWidget';
+import CheckboxWidget from '@plone/volto/components/manage/Widgets/CheckboxWidget';
+import ObjectBrowserWidget from '@plone/volto/components/manage/Widgets/ObjectBrowserWidget';
 
 import { RadioWidget } from 'volto-dropdownmenu/widget';
 import { createPortal } from 'react-dom';
@@ -110,21 +109,23 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
 
   const preventEnter = (e) => {
     if (e.code === 'Enter') {
-      const btn = e.target?.closest && e.target.closest('button');
-      if (btn) preventClick(e);
+      preventClick(e);
     }
   };
 
   useEffect(() => {
-    const form = document.querySelector('form.ui.form');
-    form?.addEventListener('click', preventClick);
+    document
+      .querySelector('form.ui.form')
+      ?.addEventListener('click', preventClick);
 
     document.querySelectorAll('form.ui.form input').forEach((item) => {
       item.addEventListener('keypress', preventEnter);
     });
 
     return () => {
-      form?.removeEventListener('click', preventClick);
+      document
+        .querySelector('form.ui.form')
+        ?.removeEventListener('click', preventClick);
       document.querySelectorAll('form.ui.form input').forEach((item) => {
         item?.removeEventListener('keypress', preventEnter);
       });

--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -100,18 +100,31 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
     };
   }
 
-  const preventEnter = (e) => {
-    if (e.code === 'Enter') {
+  const preventClick = (e) => {
+    // only prevent default when the click is on a button
+    const btn = e.target?.closest && e.target.closest('button');
+    if (btn) {
       e.preventDefault();
     }
   };
 
+  const preventEnter = (e) => {
+    if (e.code === 'Enter') {
+      const btn = e.target?.closest && e.target.closest('button');
+      if (btn) preventClick(e);
+    }
+  };
+
   useEffect(() => {
+    const form = document.querySelector('form.ui.form');
+    form?.addEventListener('click', preventClick);
+
     document.querySelectorAll('form.ui.form input').forEach((item) => {
       item.addEventListener('keypress', preventEnter);
     });
 
     return () => {
+      form?.removeEventListener('click', preventClick);
       document.querySelectorAll('form.ui.form input').forEach((item) => {
         item?.removeEventListener('keypress', preventEnter);
       });

--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -100,29 +100,18 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
     };
   }
 
-  const preventClick = (e) => {
-    e.preventDefault();
-  };
-
   const preventEnter = (e) => {
     if (e.code === 'Enter') {
-      preventClick(e);
+      e.preventDefault();
     }
   };
 
   useEffect(() => {
-    document
-      .querySelector('form.ui.form')
-      .addEventListener('click', preventClick);
-
     document.querySelectorAll('form.ui.form input').forEach((item) => {
       item.addEventListener('keypress', preventEnter);
     });
 
     return () => {
-      document
-        .querySelector('form.ui.form')
-        ?.removeEventListener('click', preventClick);
       document.querySelectorAll('form.ui.form input').forEach((item) => {
         item?.removeEventListener('keypress', preventEnter);
       });

--- a/src/widget/MenuConfigurationWidget.jsx
+++ b/src/widget/MenuConfigurationWidget.jsx
@@ -10,7 +10,7 @@ import {
   Header,
 } from 'semantic-ui-react';
 import Component from '@plone/volto/components/theme/Component/Component';
-import { TextWidget } from '@plone/volto/components/manage/Widgets';
+import TextWidget from '@plone/volto/components/manage/Widgets/TextWidget';
 import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 
 import './menu_configuration.css';

--- a/src/widget/RadioWidget.jsx
+++ b/src/widget/RadioWidget.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'semantic-ui-react';
-import { FormFieldWrapper } from '@plone/volto/components/manage/Widgets';
+import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
 import cx from 'classnames';
 import './radio_widget.css';
 


### PR DESCRIPTION
The preventClick function set on all form prevents checkbox onChange to have effects.

![Screen Recording 2026-02-17 at 13 01 43](https://github.com/user-attachments/assets/2309a794-2682-4e1a-a15e-498efaff23d4)

The problem is that the click is not applied to the component. No onChange function at any level is even triggered, which means that it is not a id problem or a onChange function problem, but the fact that the click does not trigger anything inside the component.

This does not happen on other widgets because the components (text input, buttons, etc.) intercept the click before the preventClick does as it does not propagate.
Since it seems there is actually no need for a preventClick function, I would just remove it and keep the preventEnter as it is the one that prevents the real risk of submitting the form.