### PR TITLE
fix: managed enter keypress, click and submit in menu configuration form

### DIFF
--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -99,38 +99,76 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
     };
   }
 
-  const preventClick = (e) => {
-    // only prevent default when the click is on a button
-    const btn = e.target?.closest && e.target.closest('button');
-    if (btn) {
-      e.preventDefault();
-    }
-  };
+  // const preventClick = (e) => {
+  //   // only prevent default when the click is on a button
+  //   const btn = e.target?.closest && e.target.closest('button');
+  //   if (btn) {
+  //     e.preventDefault();
+  //   }
+  // };
 
-  const preventEnter = (e) => {
-    if (e.code === 'Enter') {
-      preventClick(e);
-    }
-  };
+  // const preventEnter = (e) => {
+  //   if (e.code === 'Enter') {
+  //     preventClick(e);
+  //   }
+  // };
+
+  // two useEffects because:
+  // - the first one blocks the real problem: html default submit
+  // - the second one is to make sure Enter does not indirectly generate any submits
 
   useEffect(() => {
-    document
-      .querySelector('form.ui.form')
-      ?.addEventListener('click', preventClick);
+    // Get the main Volto HTML form.
+    // By default it treats Enter key presses and buttons as submit triggers.
+    const form = document.querySelector('form.ui.form');
 
-    document.querySelectorAll('form.ui.form input').forEach((item) => {
-      item.addEventListener('keypress', preventEnter);
-    });
+    // Prevent any form submission:
+    // - Enter pressed on inputs
+    // - Click on buttons with implicit type="submit"
+    // This avoids Volto unmounting or resetting the entire form.
+    const preventSubmit = (e) => {
+      e.preventDefault(); // Stop the native submit behavior
+      e.stopPropagation(); // Stop the event from reaching other handlers
+    };
+
+    // Listen in the capture phase to intercept the submit
+    // before Semantic UI or Volto can handle it.
+    form?.addEventListener('submit', preventSubmit, true);
 
     return () => {
-      document
-        .querySelector('form.ui.form')
-        ?.removeEventListener('click', preventClick);
-      document.querySelectorAll('form.ui.form input').forEach((item) => {
-        item?.removeEventListener('keypress', preventEnter);
-      });
+      // Cleanup: remove the listener when the component unmounts
+      form?.removeEventListener('submit', preventSubmit, true);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      // If Enter is pressed
+      if (e.key === 'Enter') {
+        const form = e.target.closest('form.ui.form');
+
+        // If we're inside the main form
+        if (form) {
+          // **Exception:** if we're inside menu-blocks-container
+          const inBlocks = e.target.closest('.menu-blocks-container');
+          if (inBlocks) {
+            // let react and volto manage Enter
+            return;
+          }
+
+          // otherwise block submit
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }
+    };
+
+    // listener in capture phase to be safe
+    document.addEventListener('keydown', handler, true);
+
+    return () => {
+      document.removeEventListener('keydown', handler, true);
+    };
   }, []);
 
   const onChangeFormData = (id, value) => {

--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -121,34 +121,34 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
     // Get the main Volto HTML form
     const form = document.querySelector('form.ui.form');
 
-    // Handler per bloccare submit espliciti o impliciti
+    // Handler to block any type of submit
     const preventSubmit = (e) => {
       e.preventDefault();
       e.stopPropagation();
     };
 
-    // Handler globale per bloccare Enter sugli input,
-    // tranne dentro menu-blocks-container
+    // global handler to stop Enter from submitting inputs
+    // exception: menu-blocks-container (to add slate blocks)
     const handleEnter = (e) => {
       if (e.key === 'Enter') {
         const targetForm = e.target.closest('form.ui.form');
         if (targetForm) {
           const inBlocks = e.target.closest('.menu-blocks-container');
           if (inBlocks) {
-            // Lascia Enter libero dentro i blocks (React/Volto crea nuovo blocco)
+            // allow enter to add blocks (React/Volto create new blocks)
             return;
           }
-          // Blocca Enter altrove per evitare submit indesiderati
+          // block enter everywhere else to prevent unwanted submit
           e.preventDefault();
           e.stopPropagation();
         }
       }
     };
 
-    // Blocca submit nativi (click su button con type submit, ecc.)
+    // prevent native submits (click on buttons that have type submit, etc.)
     form?.addEventListener('submit', preventSubmit, true);
 
-    // Blocca Enter fuori dai blocks
+    // Block Enter outside blocks
     document.addEventListener('keydown', handleEnter, true);
 
     return () => {

--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -99,24 +99,6 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
     };
   }
 
-  // const preventClick = (e) => {
-  //   // only prevent default when the click is on a button
-  //   const btn = e.target?.closest && e.target.closest('button');
-  //   if (btn) {
-  //     e.preventDefault();
-  //   }
-  // };
-
-  // const preventEnter = (e) => {
-  //   if (e.code === 'Enter') {
-  //     preventClick(e);
-  //   }
-  // };
-
-  // two useEffects because:
-  // - the first one blocks the real problem: html default submit
-  // - the second one is to make sure Enter does not indirectly generate any submits
-
   useEffect(() => {
     // Get the main Volto HTML form
     const form = document.querySelector('form.ui.form');

--- a/src/widget/MenuConfigurationForm.jsx
+++ b/src/widget/MenuConfigurationForm.jsx
@@ -118,56 +118,43 @@ const MenuConfigurationForm = ({ id, menuItem, onChange, deleteMenuItem }) => {
   // - the second one is to make sure Enter does not indirectly generate any submits
 
   useEffect(() => {
-    // Get the main Volto HTML form.
-    // By default it treats Enter key presses and buttons as submit triggers.
+    // Get the main Volto HTML form
     const form = document.querySelector('form.ui.form');
 
-    // Prevent any form submission:
-    // - Enter pressed on inputs
-    // - Click on buttons with implicit type="submit"
-    // This avoids Volto unmounting or resetting the entire form.
+    // Handler per bloccare submit espliciti o impliciti
     const preventSubmit = (e) => {
-      e.preventDefault(); // Stop the native submit behavior
-      e.stopPropagation(); // Stop the event from reaching other handlers
+      e.preventDefault();
+      e.stopPropagation();
     };
 
-    // Listen in the capture phase to intercept the submit
-    // before Semantic UI or Volto can handle it.
-    form?.addEventListener('submit', preventSubmit, true);
-
-    return () => {
-      // Cleanup: remove the listener when the component unmounts
-      form?.removeEventListener('submit', preventSubmit, true);
-    };
-  }, []);
-
-  useEffect(() => {
-    const handler = (e) => {
-      // If Enter is pressed
+    // Handler globale per bloccare Enter sugli input,
+    // tranne dentro menu-blocks-container
+    const handleEnter = (e) => {
       if (e.key === 'Enter') {
-        const form = e.target.closest('form.ui.form');
-
-        // If we're inside the main form
-        if (form) {
-          // **Exception:** if we're inside menu-blocks-container
+        const targetForm = e.target.closest('form.ui.form');
+        if (targetForm) {
           const inBlocks = e.target.closest('.menu-blocks-container');
           if (inBlocks) {
-            // let react and volto manage Enter
+            // Lascia Enter libero dentro i blocks (React/Volto crea nuovo blocco)
             return;
           }
-
-          // otherwise block submit
+          // Blocca Enter altrove per evitare submit indesiderati
           e.preventDefault();
           e.stopPropagation();
         }
       }
     };
 
-    // listener in capture phase to be safe
-    document.addEventListener('keydown', handler, true);
+    // Blocca submit nativi (click su button con type submit, ecc.)
+    form?.addEventListener('submit', preventSubmit, true);
+
+    // Blocca Enter fuori dai blocks
+    document.addEventListener('keydown', handleEnter, true);
 
     return () => {
-      document.removeEventListener('keydown', handler, true);
+      // Cleanup all listeners
+      form?.removeEventListener('submit', preventSubmit, true);
+      document.removeEventListener('keydown', handleEnter, true);
     };
   }, []);
 


### PR DESCRIPTION
Used useEffect to manage html default submit and to manage enter keypress.

- block any type of native submits through enter
- block any type of submits through submit-type buttons
- add exception for menu-blocks-container to allow Volto to add new blocks

